### PR TITLE
Use better algorithms

### DIFF
--- a/src/clustering_bench.ml
+++ b/src/clustering_bench.ml
@@ -5,10 +5,23 @@
  * asak is distributed under the terms of the MIT license. See the
  * included LICENSE file for details. *)
 
+module Wtree = struct
+  type 'a wtree =
+    | Node of (int * 'a wtree * 'a wtree)
+    | Leaf of 'a
+
+  let fold_tree n l =
+    let rec aux = function
+      | Leaf a -> l a
+      | Node (f,a,b) -> n f (aux a) (aux b)
+    in aux
+
+  let size_of_tree f =
+    fold_tree (fun _ a b -> 1 + a + b) f
+end
 open Wtree
 
 module Distance = struct
-
   type t = Regular of int | Infinity
 
   let compare x y =

--- a/src/clustering_bench.ml
+++ b/src/clustering_bench.ml
@@ -233,12 +233,17 @@ let cluster ?filter_small_trees (hash_list : ('a * (Hash.t * Hash.t list)) list)
       (fun (acc,m) (main_hash,xs) -> main_hash::acc,HMap.add main_hash xs m)
       ([],HMap.empty) start in
   let create_leaf k = Leaf (HMap.find k assoc_hash_ident_list) in
-  let was_seen,distance_matrix = compute_all_sym_diff cores assoc_main_subs start in
+  debug "start";
+  let was_seen,distance_matrix = compute_all_sym_diff assoc_main_subs start in
+  debug "compute_all_sym_diff done";
   let hdistance_matrix = convert_map_to_hm distance_matrix in
+  debug "convert_map_to_hm done";
   let lst,alone = List.partition (fun x -> HSet.mem x was_seen) start in
   let surapprox = surapproximate_classes hdistance_matrix lst in
+  debug "surapproximate_classes done";
   let surapprox = List.map (List.map (fun x -> Leaf x)) surapprox in
-  let dendrogram_list = hierarchical_clustering cores hdistance_matrix surapprox in
+  let dendrogram_list = hierarchical_clustering hdistance_matrix surapprox in
+  debug "hierarchical_clustering done";
   let cluster =
     List.sort
       (fun x y -> - (compare_size_of_trees x y))

--- a/src/clustering_bench.ml
+++ b/src/clustering_bench.ml
@@ -218,7 +218,9 @@ let compute_all_sym_diff_fast_multiocc children xs =
           let common_occurrences = min occurrences_in_parent occurrences_in_neighbor in
           increment_key diffs neighbor (weight * common_occurrences) in
       Hashtbl.iter add_common_weight child_occurrences in
-    List.iter (add_child ~parent:x) (Hashtbl.find children x);
+    Hashtbl.find children x
+    |> HSet.of_list
+    |> HSet.iter (add_child ~parent:x);
     diffs
   in
   let nodes = ref HSet.empty in
@@ -670,8 +672,8 @@ let fake_inputs ~set_size ~cluster_size ~cluster_nb =
 let multiocc_testcase =
   (* from @nobrakal *)
   let child = 1,"child" in
-  let first = (100,"first"),[child] in
-  let second = (100,"second"),[child; child] in
+  let first = (100,"first"),[child; child] in
+  let second = (100,"second"),[child] in
   [("first",first);("second",second)]
 
 let () =

--- a/src/clustering_bench.ml
+++ b/src/clustering_bench.ml
@@ -1,0 +1,269 @@
+(* This file is part of asak.
+ *
+ * Copyright (C) 2019 IRIF / OCaml Software Foundation.
+ *
+ * asak is distributed under the terms of the MIT license. See the
+ * included LICENSE file for details. *)
+
+open Wtree
+
+module Distance = struct
+
+  type t = Regular of int | Infinity
+
+  let compare x y =
+    match x with
+    | Infinity -> 1
+    | Regular x' ->
+       match y with
+       | Infinity -> -1
+       | Regular y' -> compare x' y'
+
+  let lt x y =
+    compare x y = -1
+
+  let max x y =
+    if compare x y <= 0
+    then y
+    else x
+
+  let min x y =
+    if compare x y <= 0
+    then x
+    else y
+end
+
+let symmetric_difference x y =
+  let rec aux x y =
+    match x,y with
+    | [],z|z,[] -> false,z
+    | xx::xs,yy::ys ->
+       match compare xx yy with
+       | (-1) ->
+          let b,ndiff = aux xs y in
+          b,xx::ndiff
+       | 0 ->
+          let _,ndiff = aux xs ys in
+          true,ndiff
+       | 1 ->
+          let b,ndiff = aux x ys in
+          b,yy::ndiff
+       | _ -> failwith "symmetric_difference"
+  in
+  let b,res = aux x y in
+  if b
+  then Some res
+  else None
+
+let sum_of_fst xs = List.fold_left (fun acc (a,_) -> acc + a) 0 xs
+
+let semimetric x y =
+  let open Distance in
+  match symmetric_difference x y with
+  | None -> Infinity
+  | Some diff -> Regular (sum_of_fst diff)
+
+module Hash =
+  struct
+    type t = int * string
+    let compare = compare
+  end
+
+module HashPairs =
+  struct
+    type t = Hash.t * Hash.t
+    let compare = compare
+  end
+
+module HPMap = Map.Make(HashPairs)
+module HMap = Map.Make(Hash)
+module HSet = Set.Make(Hash)
+
+let split_by_cores cores xs =
+  let len = List.length xs in
+  let nb_per_cores = max 1 (len / cores) in
+  let (_,left,cored) =
+    List.fold_left
+      (fun (i,xs,acc) x ->
+        if i mod nb_per_cores = 0
+        then 1,[x],(xs::acc)
+        else i+1,x::xs,acc) (1,[],[]) xs in
+  left::cored
+
+let add_if_non_inf assoc_main_subs x ((s,m) as acc) y =
+  if x < y
+  then
+    match semimetric (Hashtbl.find assoc_main_subs x) (Hashtbl.find assoc_main_subs y) with
+    | Infinity -> acc
+    | Regular dist ->
+       HSet.add x (HSet.add y s),
+       HPMap.add (x,y) dist m
+  else acc
+
+(* NB: the returned hashtable contains only keys (x,y) where x < y.
+   This is not a problem since the distance is symmetric.
+ *)
+let compute_all_sym_diff cores assoc_main_subs xs =
+  let cored = split_by_cores cores xs in
+  let get_fst _ x _ = Some x in
+  let neutral = (HSet.empty, HPMap.empty) in
+  let map xs' =
+    List.fold_left
+      (fun acc x -> List.fold_left (add_if_non_inf assoc_main_subs x) acc xs) neutral xs' in
+  let fold (s1,m1) (s2,m2) = HSet.union s1 s2, HPMap.union get_fst m1 m2 in
+  List.fold_left fold neutral @@
+    Parmap.parmap ~ncores:cores ~chunksize:1 map (Parmap.L cored)
+
+let dist semimetric x y =
+  let rec aux x y =
+    match x,y with
+    | Leaf x, Leaf y -> semimetric x y
+    | Node (_,u,v), l | l, Node (_,u,v) ->
+       let open Distance in
+       match aux u l with
+       | Infinity -> Infinity (* Avoid the computation of (aux v l) when possible *)
+       | x -> max x (aux v l)
+  in aux x y
+
+let get_min_dist semimetric x y xs =
+  let xs = x::y::xs in
+  List.fold_left
+    (fun min x ->
+      List.fold_left
+        (fun min y ->
+          let d = dist semimetric x y in
+          if Distance.lt d (fst min)
+          then (d,(x,y))
+          else min
+        ) min xs
+    ) (dist semimetric x y, (x,y)) xs
+
+let merge p u v xs =
+  let xs = List.filter (fun x -> x != u && x != v) xs in
+  (Node (p,u,v))::xs
+
+let semimetric_from tbl x y =
+  try
+    let value =
+      Hashtbl.find tbl (if x < y then (x,y) else (y,x)) in
+    Distance.Regular value
+  with Not_found -> Distance.Infinity
+
+let iter_on_cart_prod f xs =
+  List.iter (fun x -> List.iter (f x) xs) xs
+
+let classes_of_uf xs =
+  let m =
+    List.fold_left
+      (fun m (x',x) ->
+        let x = UnionFind.get x in
+        try
+          let xs = HMap.find x m in
+          HMap.add x (x'::xs) m
+        with | Not_found -> HMap.add x [x'] m
+      ) HMap.empty xs in
+  HMap.fold (fun _ xs acc -> xs::acc) m []
+
+(* Surapproximate classes by using the transitive closure of xRy <=> dist x y < Infinity.
+   If not (xRy) => dist x y = Infinity, thus x and y cannot be in the same class.
+ *)
+let surapproximate_classes tbl xs =
+  let xs' = List.map (fun x -> x, UnionFind.make x) xs in
+  let try_to_merge (x',x) (y',y) =
+    if x' < y'
+    then
+      if Hashtbl.mem tbl (x',y')
+      then let _ = UnionFind.union x y in () in
+  iter_on_cart_prod try_to_merge xs';
+  classes_of_uf xs'
+
+(* Compute a hierarchical clustering *)
+let refine_class tbl (xs : Hash.t wtree list) =
+  let rec compute xs =
+    match xs with
+    | [] | [_] -> xs
+    | x::y::_  ->
+       let (p, (u,v)) = get_min_dist (semimetric_from tbl) x y xs in
+       match p with
+       | Infinity -> xs
+       | Regular p -> compute (merge p u v xs)
+  in compute xs
+
+let hierarchical_clustering cores tbl (xs : Hash.t wtree list list) =
+  let cored = split_by_cores cores xs in
+  let rafine_class = List.fold_left (fun acc x -> List.rev_append (refine_class tbl x) acc) [] in
+  Parmap.parmapfold ~ncores:cores ~chunksize:1
+    rafine_class (Parmap.L cored) List.rev_append [] List.rev_append
+
+let add_in_cluster map (x,h) =
+  match HMap.find_opt h map with
+  | None -> HMap.add h [x] map
+  | Some ys -> HMap.add h (x::ys) map
+
+let create_start_cluster hash_list =
+  let cluster = List.fold_left add_in_cluster HMap.empty hash_list in
+  HMap.fold (fun k xs acc -> (k,xs)::acc) cluster []
+
+let compare_size_of_trees x y =
+  compare (size_of_tree List.length x) (size_of_tree List.length y)
+
+let convert_map_to_hm m =
+  let size = HPMap.cardinal m in
+  let ht = Hashtbl.create size in
+  HPMap.iter (Hashtbl.add ht) m;
+  ht
+
+let add_in_assoc tbl (_,(h,xs)) =
+  if not (Hashtbl.mem tbl h)
+  then Hashtbl.add tbl h (List.sort compare xs)
+
+let cluster ?cores ?filter_small_trees (hash_list : ('a * (Hash.t * Hash.t list)) list) =
+  let cores =
+    match cores with
+    | None -> Parmap.get_default_ncores ()
+    | Some x -> x in
+  let hash_list =
+    match filter_small_trees with
+    | None -> hash_list
+    | Some t -> List.filter (fun (_,((p,_),_)) -> p >= t) hash_list in
+  let assoc_main_subs = Hashtbl.create (List.length hash_list) in
+  List.iter (add_in_assoc assoc_main_subs) hash_list;
+  let start = create_start_cluster (List.rev_map (fun (k,(h,_)) -> k,h) hash_list) in
+  let start,assoc_hash_ident_list =
+    List.fold_left
+      (fun (acc,m) (main_hash,xs) -> main_hash::acc,HMap.add main_hash xs m)
+      ([],HMap.empty) start in
+  let create_leaf k = Leaf (HMap.find k assoc_hash_ident_list) in
+  let was_seen,distance_matrix = compute_all_sym_diff cores assoc_main_subs start in
+  let hdistance_matrix = convert_map_to_hm distance_matrix in
+  let lst,alone = List.partition (fun x -> HSet.mem x was_seen) start in
+  let surapprox = surapproximate_classes hdistance_matrix lst in
+  let surapprox = List.map (List.map (fun x -> Leaf x)) surapprox in
+  let dendrogram_list = hierarchical_clustering cores hdistance_matrix surapprox in
+  let cluster =
+    List.sort
+      (fun x y -> - (compare_size_of_trees x y))
+      (List.map (fold_tree (fun a b c -> Node (a,b,c)) create_leaf) dendrogram_list) in
+  cluster @ (List.rev_map create_leaf alone)
+
+let print_cluster show cluster =
+  let rec aux i = function
+    | Leaf x ->
+       begin
+         print_string (String.make i ' ');
+         List.iter (fun x -> print_string (show x ^ " ")) x;
+         print_endline "";
+       end
+    | Node (w,x,y) ->
+       begin
+         print_string (String.make i ' ');
+         print_string ("Node " ^ string_of_int w ^":");
+         print_endline "";
+         aux (i+1) x;
+         aux (i+1) y
+       end
+  in
+  let pclass i x =
+    print_endline ("Class " ^ string_of_int i ^ ":");
+    aux 1 x
+  in List.iteri pclass cluster

--- a/src/clustering_bench.ml
+++ b/src/clustering_bench.ml
@@ -33,7 +33,7 @@ module Distance = struct
        | Regular y' -> compare x' y'
 
   let lt x y =
-    compare x y = -1
+    compare x y < 0
 
   let max x y =
     if compare x y <= 0
@@ -52,17 +52,16 @@ let symmetric_difference x y =
     match x,y with
     | [],z|z,[] -> false,z
     | xx::xs,yy::ys ->
-       match compare xx yy with
-       | (-1) ->
-          let b,ndiff = aux xs y in
-          b,xx::ndiff
-       | 0 ->
-          let _,ndiff = aux xs ys in
-          true,ndiff
-       | 1 ->
+       let cmp = compare xx yy in
+       if cmp < 0 then
+         let b,ndiff = aux xs y in
+         b,xx::ndiff
+       else if cmp > 0 then
           let b,ndiff = aux x ys in
           b,yy::ndiff
-       | _ -> failwith "symmetric_difference"
+       else
+          let _,ndiff = aux xs ys in
+          true,ndiff
   in
   let b,res = aux x y in
   if b


### PR DESCRIPTION
(cc @nobrakal and @yurug)

Asak can be expensive to run on large corpus of code, so `src/clustering.ml` uses Parmap to parallelize computations. This PR proposes an alternative route, which is to improve the algorithms to go faster.

I propose a better algorithm for computing distances between all pairs of Lambda fingerprints, and a better algorithm to cluster the fingerprints into dendrograms.

I worked by first copying the file `src/clustering.ml` into a new file `src/clustering_bench.ml` which I then modified to measure runtime and experiment with algorithms. (I also removed all uses of Parmap and UnionFind in the code, and inlined the definition of Wtree; the file is completely self-contained). I wrote a random generator of fingerprints, that can be tuned to generate small or large sets of sub-hashes (large sets spend a lot of time in symmetric-difference copmutation), and small or large connected components (large components spend a lot of time in clustering). I edited the various parts one commit at a time, keeping the old code for performance comparison.

For example, running the program with fingerprint of cardinality 20 to generate 20 connected components of 150 fingerprints prints the following timing information:

```
[    0.024729] start
[   11.511494] compute_all_sym_diff done
[    0.809088] compute_all_sym_diff_fast done
[   24.843792] check compute_all_sym_diff
[    0.078135] convert_map_to_hm done
[    1.672870] surapproximate_classes done
[    1.925790] adjacency_list done
[    0.144706] surapproximate_classes_nouf done
[    0.005801] check surapproximate_classes
[   21.723186] hierarchical_clustering done
[    0.875388] hierarchical_clustering_fast done
```

On this run, the old algorithm for symmetric difference (after removing all the Parmap stuff, so purely sequential) takes 11.5s, and the new algorithm takes 0.8s. The old algorithm for clustering takes 21.7s, the new algorithm takes 0.9s. There is also a surapproximate_classes_nouf function (0.14s instead of 1.7s), for which the goal is not performance (this approximation is not a bottleneck of the previous code) but simplification: Union-Find is important for incremental unification computation (where you alternate same-connected-component queries with addition of new unification edges), but this is simply a connected-component computation that can be done with a graph traversal.

(The new algorithms are documented in code comments. At a high level: the symmetric-differences algorithm computes the distance from a node to all its neighbors in a single traversal of its own children, and the clustering algorithm uses a priority queue to avoid having to recompute the minimal pair at each step.)

For all_sym_diff and surapproximate_classes, there is a check that the new algorithm returns exactly the same result as the old algorithm. There is no such check for the clustering algorithm, because the results are *not* the same. There may be a bug in the new code, but there are also many reasons why two correct algorithms would return different results: the order of children in a dendrogram is irrelevant, and the algorithm does not specifies what to do when several pairs-of-trees are at the same minimal distance (typically, if all leaves are at the same distance from each other, any tree shape is a valid result). I tried to get the two algorithms to agree on their choices (by picking a minimal pair for lexicographic ordering), but it didn't work and it made the code more complex.

The old code represents distance information with a `('a * 'a, int) Hashtbl.t` structure. This makes it difficult to implement certain graph algorithms (typically, connected-components computation) where we need to get the list of all neighbors of a given node. For this reason I perform a conversion to an adjacency-list presentation in the middle of the code. I think that it would be simpler to use adjacency lists from the start, for example using a `('a, ('a, int) Hashtbl.t) Hashtbl.t` structure (my adjacency lists are simpler because I rely on the pair-hashmap for distance information). This would require a more global rewrite of the code, I didn't do it.

This PR changes only the code in `clustering_bench.ml`. If you like the algorithms proposed and wish to use them in production, they need to be integrated into `clustering.ml` proper. I didn't do it myself because I don't have the setup to reproduce the real-world experiments, or even conveniently play with the whole toolchain (so for me the isolated `clustering_bench` is easier).
